### PR TITLE
chore: Enable UndefinedBehaviorSanitizer

### DIFF
--- a/src/moon.pkg.json
+++ b/src/moon.pkg.json
@@ -11,7 +11,7 @@
   },
   "link": {
     "native": {
-      "cc-flags": "-fsanitize=address"
+      "cc-flags": "-fwrapv -fsanitize=address -fsanitize=undefined"
     }
   }
 }


### PR DESCRIPTION
We can remove the redundant option `-fwrapv` later, here is the relevant issus https://github.com/moonbitlang/moon/issues/604